### PR TITLE
Filter out `aarch64` (until we get official builders)

### DIFF
--- a/src/UpdateLogic.hs
+++ b/src/UpdateLogic.hs
@@ -241,7 +241,8 @@ findInstallersBuildKite apiToken buildNum buildUrl = do
   let buildDesc = format ("Buildkite build #"%d) buildNum
   arts <- listArtifactsForBuild apiToken buildkiteOrg pipelineDaedalus buildNum
   let arts' = [ (art, arch) | (art, Just arch) <- [ (art, bkArtifactInstallerArch art) | art <- arts ] ]
-  forInstallers buildDesc (const True) arts' $ \(art, arch) -> do
+  let filterOutAarch64 = \(art, _) -> not ("aarch64" `T.isInfixOf` artifactFilename art)
+  forInstallers buildDesc filterOutAarch64 arts' $ \(art, arch) -> do
     -- ask Buildkite what the download URL is
     url <- BK.getArtifactURL apiToken buildkiteOrg pipelineDaedalus buildNum art
     pure $ CIResult


### PR DESCRIPTION
Currently sometimes `aarch64-darwin` is selected as `Mac64` and uploaded to S3

I have it on my list to fix (add proper arch+OS tuple, like in Nix), but just a quick fix for now

Note: this patch has already been tested during the last release and is present on `testnet-deployer`

/cc @jbgi 